### PR TITLE
Delete product from cart

### DIFF
--- a/seed.js
+++ b/seed.js
@@ -5,6 +5,7 @@ const db = require('./server/db/index')
 const {User} = require('./server/db/models/models_index')
 const {Product} = require('./server/db/models/models_index')
 const {Order} = require('./server/db/models/models_index')
+const {OrderToItem} = require('./server/db/models/models_index')
 // OrderItems
 //   -
 //   orderId int FK > - Order.orderId
@@ -420,6 +421,19 @@ const products = [
   }
 ]
 
+const cartItems = [
+  {
+    productId: 1,
+    orderId: 2,
+    quantity: 1
+  },
+  {
+    productId: 2,
+    orderId: 1,
+    quantity: 5
+  }
+]
+
 // seed your database here!
 const seed = async () => {
   try {
@@ -441,6 +455,13 @@ const seed = async () => {
         return Product.create(product)
       })
     )
+
+    await Promise.all(
+      cartItems.map(cartItem => {
+        return OrderToItem.create(cartItem)
+      })
+    )
+
     // console.log(green('Seeding success!'))
     console.log('Seeding success!')
     db.close()

--- a/server/api/orders.js
+++ b/server/api/orders.js
@@ -115,14 +115,20 @@ router.delete('/remove', async (req, res, next) => {
     let OrderToItemInstance = null
     //Checks to see if the product is currently on this order
     if (existingOrderToItem) {
-      //subtracts the new quantity to the current quatity when the product is already on the order
-      OrderToItemInstance = await OrderToItem.decrement('quantity', {
-        by: req.body.quantity,
-        where: {
-          orderId: req.body.orderId,
-          productId: req.body.productId
-        }
-      })
+      if (existingOrderToItem.quantity - req.body.quantity < 0) {
+        res.send(
+          'Cannot remove more of this product than there is left in the cart.'
+        )
+      } else {
+        //subtracts the new quantity to the current quatity when the product is already on the order
+        OrderToItemInstance = await OrderToItem.decrement('quantity', {
+          by: req.body.quantity,
+          where: {
+            orderId: req.body.orderId,
+            productId: req.body.productId
+          }
+        })
+      }
     } else {
       //Adds the product to the order with the quantity passed in
       res.status(404).send('Nothing to remove')

--- a/server/api/orders.js
+++ b/server/api/orders.js
@@ -106,10 +106,13 @@ router.post('/add', async (req, res, next) => {
 
 //Deletes an ordertoitem record with the given id.
 //uses deleteitem path so it is not mistaken for deleting an entire cart.
-router.delete('/deleteitem/:cartItemId', async (req, res, next) => {
+router.delete('/deleteitem', async (req, res, next) => {
   try {
-    const deletedOrder = await Order.destroy({
-      where: {id: req.params.cartItemId}
+    const deletedOrder = await OrderToItem.destroy({
+      where: {
+        productId: req.body.productId,
+        orderId: req.body.orderId
+      }
     })
     if (deletedOrder) {
       res.send('Order deleted')

--- a/server/db/models/order_to_item.js
+++ b/server/db/models/order_to_item.js
@@ -5,7 +5,9 @@ const OrderToItem = db.define('order_to_item', {
   quantity: {
     type: Sequelize.INTEGER,
     validate: {
-      min: 0
+      min: {
+        args: 0
+      }
     }
   }
 })

--- a/server/db/models/order_to_item.js
+++ b/server/db/models/order_to_item.js
@@ -5,9 +5,7 @@ const OrderToItem = db.define('order_to_item', {
   quantity: {
     type: Sequelize.INTEGER,
     validate: {
-      min: {
-        args: 0
-      }
+      min: 0
     }
   }
 })


### PR DESCRIPTION
Deleted console.logs and added delete route for ordertoitems. Used 'api/orders/deleteitem' path instead of /api/orders so as not to confuse this route with one that deletes orders. 

Currently the route finds the ordertoitem by using a productId and orderId. Typically we delete by using an id passed in the params (since ordertoitem is a through table, it currently has no primary key). We could discuss whether we'd like to add a pk to the ordertoitems table or keep this way of sending a body with product and order ids along with our delete request.

Added ordertoitems instances in seed file for testing. 

