### PR TITLE
reverting to before delete route

### DIFF
--- a/server/api/orders.js
+++ b/server/api/orders.js
@@ -27,6 +27,7 @@ router.get('/:userId/getCart', async (req, res, next) => {
         orderSubmittedDate: null
       }
     })
+
     console.log('CART>>>>>>,', existingCart)
     existingCart = await Order.findAll({
       includes: [


### PR DESCRIPTION
This pr should revert the state of our repo to just before delete functionality was added. It also gets rid of the 'includes' eager loading in the get cart route.
